### PR TITLE
Add missing iris dataset support in histogram rendering

### DIFF
--- a/server.R
+++ b/server.R
@@ -55,6 +55,13 @@ server <- function(input, output, session) {
            xlab = input$variable,
            col = input$color,
            border = "white")
+    } else if(input$dataset == "iris") {
+      hist(data[[input$variable]], 
+           breaks = input$bins,
+           main = paste("Distribution of", input$variable),
+           xlab = input$variable,
+           col = input$color,
+           border = "white")
     }
     # MISSING: iris dataset case - this causes the crash!
     # Students need to add the iris case or make it generic


### PR DESCRIPTION
## Problem

The Shiny app was not displaying histograms for the iris dataset. While the dataset was selectable in the UI, the rendering logic was missing the conditional branch to handle iris data, causing the histogram to not appear when iris was selected.

## Solution

Added the missing else if condition for the iris dataset in the histogram rendering logic. This ensures that when users select "iris" from the dataset dropdown, the histogram is properly generated and displayed.

## Changes

- Added iris dataset handling in the histogram rendering conditional block
- Uses the same histogram configuration: breaks, main title, xlabel, color, and border styling

## Testing

- [x] Verified iris dataset now displays histograms correctly
- [x] Confirmed other datasets (mtcars, faithful) still work as expected
